### PR TITLE
Make CPU device request mandatory in pod spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Annotation schema is following and the name for the annotation is `<resourceBase
 ```
 An example is provided in cpu-test.yaml pod manifest in the deployment folder.
 
+### Restrictions
+
+Following restrictions apply when allocating cpu from pools and configuring pools:
+
+* There can be only one shared pool in the node
+* Containter can ask cpus from one type of pool only (shared or exclusive)
+
 ## Build
 
 Mutating webhook

--- a/cmd/cpu-device-plugin/cpu-device-plugin.go
+++ b/cmd/cpu-device-plugin/cpu-device-plugin.go
@@ -218,6 +218,11 @@ func createPluginsForPools() error {
 	glog.Infof("Pool configuration %v", poolConf)
 	for poolName, pool := range poolConf.Pools {
 		if strings.HasPrefix(poolName, "shared") {
+			if sharedCPUs != "" {
+				err = fmt.Errorf("Only one shared pool allowed")
+				glog.Errorf("Pool config : %v", poolConf)
+				break
+			}
 			sharedCPUs = pool.CPUs
 		}
 		cdm := newCPUDeviceManager(poolName, pool, sharedCPUs)
@@ -258,7 +263,7 @@ func main() {
 	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	if err := createPluginsForPools(); err != nil {
-		panic("Failed to start device plugin")
+		glog.Fatalf("Failed to start device plugin: %v", err)
 	}
 
 	/* Monitor file changes for kubelet socket file and termination signals */

--- a/cmd/process-starter/process_starter.go
+++ b/cmd/process-starter/process_starter.go
@@ -118,10 +118,18 @@ func main() {
 			cmd := exec.Command(process.ProcName, process.Args...)
 			if strings.HasPrefix(process.PoolName, "exclusive") {
 				exclCPUList = setAffinity(process.CPUs, exclCPUList)
+				if nil == exclCPUList {
+					fmt.Printf("Failed to set affinity")
+					os.Exit(1)
+				}
 			} else {
 				/* It is shared pool */
 				sharedCPUList := cpuListStrToIntSlice(poolConf.Pools[process.PoolName].CPUs)
 				setAffinity(len(sharedCPUList), sharedCPUList)
+				if nil == sharedCPUList {
+					fmt.Printf("Failed to set affinity")
+					os.Exit(1)
+				}
 
 			}
 			cmd.Stdout = os.Stdout

--- a/cmd/webhook/webhook_test.go
+++ b/cmd/webhook/webhook_test.go
@@ -136,6 +136,10 @@ func handleAndChekAdmReview(t *testing.T, admReviewReq []byte, expectedPatches [
 			t.Errorf("Admission review response patch unmarshal error %v:%v\n", err, rr.Body)
 			t.FailNow()
 		}
+		if expectedPatches == nil {
+			t.Errorf("Patch received but not expected")
+			t.FailNow()
+		}
 	} else {
 		if expectedPatches != nil {
 			t.Errorf("Patch not received but expected patches defined")
@@ -212,4 +216,55 @@ func TestMutatePodExclusiveCpu(t *testing.T) {
 			Value: json.RawMessage(`{"name":"cpu-pooler-config","configMap":{ "name":"cpu-pooler-configmap"} }`)},
 	}
 	handleAndChekAdmReview(t, admReviewReq, expectedPatches, nil)
+}
+func TestMutatePodWrongPoolValueRequest(t *testing.T) {
+
+	admReviewReq, err := ioutil.ReadFile("../../test/testdata/pod-spec-wrong-pool-value-req.json")
+	if err != nil {
+		t.Errorf("Could not read pod spec")
+	}
+
+	handleAndChekAdmReview(t, admReviewReq, nil, nil)
+}
+func TestMutatePodWrongExclusivePoolValueRequest(t *testing.T) {
+
+	admReviewReq, err := ioutil.ReadFile("../../test/testdata/pod-spec-wrong-excl-pool-value-req.json")
+	if err != nil {
+		t.Errorf("Could not read pod spec")
+	}
+
+	admReviewResp := handleAndChekAdmReview(t, admReviewReq, nil, nil)
+	if admReviewResp.Response.Allowed == true {
+		t.Errorf("Pod unexpectedly allowed")
+	}
+}
+
+func TestMutateMissinPoolInResource(t *testing.T) {
+
+	admReviewReq, err := ioutil.ReadFile("../../test/testdata/pod-spec-pool-req-missing.json")
+	if err != nil {
+		t.Errorf("Could not read pod spec")
+	}
+
+	handleAndChekAdmReview(t, admReviewReq, nil, nil)
+}
+
+func TestMutateAnnotationPoolMissingInResource(t *testing.T) {
+
+	admReviewReq, err := ioutil.ReadFile("../../test/testdata/pod-spec-excl-pool-req-missing.json")
+	if err != nil {
+		t.Errorf("Could not read pod spec")
+	}
+
+	handleAndChekAdmReview(t, admReviewReq, nil, nil)
+}
+
+func TestMutateBothPoolTypesRequestedInResource(t *testing.T) {
+
+	admReviewReq, err := ioutil.ReadFile("../../test/testdata/pod-spec-both-pool-types-req.json")
+	if err != nil {
+		t.Errorf("Could not read pod spec")
+	}
+
+	handleAndChekAdmReview(t, admReviewReq, nil, nil)
 }

--- a/deployment/cpu-test-exclusive.yaml
+++ b/deployment/cpu-test-exclusive.yaml
@@ -22,3 +22,10 @@ spec:
     imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 80
+    resources:
+      requests:
+        memory: 2000Mi
+        nokia.k8s.io/exclusive-pool: "3"
+      limits:
+        memory: 2000Mi
+        nokia.k8s.io/exclusive-pool: "3"

--- a/deployment/cpu-test.yaml
+++ b/deployment/cpu-test.yaml
@@ -33,7 +33,9 @@ spec:
     resources:
       requests:
         memory: 2000Mi
+        nokia.k8s.io/shared-pool: "160"
       limits:
+        nokia.k8s.io/shared-pool: "160"
         memory: 2000Mi
   - name: busyloop
     image: busyloop

--- a/internal/types/cpu-annotation.go
+++ b/internal/types/cpu-annotation.go
@@ -41,12 +41,12 @@ var validationErrStr = map[int]string{
 
 // Containers returns container name string in annotation
 func (cpuAnnotation CPUAnnotation) Containers() []string {
-	var containersToPatch []string
+	var containers []string
 
 	for _, cont := range cpuAnnotation {
-		containersToPatch = append(containersToPatch, cont.Name)
+		containers = append(containers, cont.Name)
 	}
-	return containersToPatch
+	return containers
 }
 
 // ContainerSharedCPUTime returns sum of cpu time requested from shared pool by a container
@@ -57,6 +57,23 @@ func (cpuAnnotation CPUAnnotation) ContainerSharedCPUTime(container string) int 
 		if cont.Name == container {
 			for _, process := range cont.Processes {
 				if strings.HasPrefix(process.PoolName, "shared") {
+					cpuTime += process.CPUs
+				}
+			}
+		}
+	}
+	return cpuTime
+
+}
+
+// ContainerExclusiveCPU returns sum of cpu time requested from exclusive pool by a container
+func (cpuAnnotation CPUAnnotation) ContainerExclusiveCPU(container string) int {
+	var cpuTime int
+
+	for _, cont := range cpuAnnotation {
+		if cont.Name == container {
+			for _, process := range cont.Processes {
+				if strings.HasPrefix(process.PoolName, "exclusive") {
 					cpuTime += process.CPUs
 				}
 			}

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -7,6 +7,8 @@ import (
 	"os"
 )
 
+// GetNodeLabels returns node labels.
+// NODE_NAME environment variable is used to determine the node
 func GetNodeLabels() map[string]string {
 	// creates the in-cluster config
 	config, err := rest.InClusterConfig()

--- a/test/testdata/pod-spec-both-pool-types-req.json
+++ b/test/testdata/pod-spec-both-pool-types-req.json
@@ -75,12 +75,12 @@
 			"resources": {
                             "requests": {
                                 "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/shared-cpupool": "200",
                                 "memory": "2000Mi"
                             },
                             "limits": {
                                 "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/shared-cpupool": "200",
                                 "memory": "2000Mi"
                             }
                         }
@@ -90,10 +90,7 @@
             "metadata": {
                 "creationTimestamp": null,
                 "namespace": "default",
-                "name": "cpupod",
-                "annotations": {
-                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   }, {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   },{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"3\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool2\"\n   }\n]\n}]\n"
-                }
+                "name": "cpupod"
             }
         },
         "namespace": "default",

--- a/test/testdata/pod-spec-excl-pool-req-missing.json
+++ b/test/testdata/pod-spec-excl-pool-req-missing.json
@@ -72,15 +72,13 @@
                                 "containerPort": 80
                             }
                         ],
-			"resources": {
+                        "resources": {
                             "requests": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/exclusive-pool1": "3",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/exclusive-pool1": "3",
                                 "memory": "2000Mi"
                             }
                         }
@@ -92,7 +90,7 @@
                 "namespace": "default",
                 "name": "cpupod",
                 "annotations": {
-                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   }, {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   },{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"3\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool2\"\n   }\n]\n}]\n"
+                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-pool\"\n   },\n   {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\", \"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"pool\": \"exclusive-pool\",\n     \"cpus\": 2\n   } \n]\n}]\n"
                 }
             }
         },

--- a/test/testdata/pod-spec-pool-req-missing.json
+++ b/test/testdata/pod-spec-pool-req-missing.json
@@ -72,15 +72,11 @@
                                 "containerPort": 80
                             }
                         ],
-			"resources": {
+                        "resources": {
                             "requests": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
                                 "memory": "2000Mi"
                             }
                         }
@@ -92,7 +88,7 @@
                 "namespace": "default",
                 "name": "cpupod",
                 "annotations": {
-                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   }, {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   },{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"3\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool2\"\n   }\n]\n}]\n"
+                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 150,\n     \"pool\": \"shared-pool\"\n   },\n   {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\", \"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"pool\": \"shared-pool\",\n     \"cpus\": 10\n   } \n]\n}]\n"
                 }
             }
         },

--- a/test/testdata/pod-spec-shared-pool-req.json
+++ b/test/testdata/pod-spec-shared-pool-req.json
@@ -74,13 +74,13 @@
                         ],
                         "resources": {
                             "requests": {
-                                "nokia.com/cpupool2": "2",
-                                "nokia.com/sharedpool": "10",
+                                "nokia.k8s.io/cpupool2": "2",
+                                "nokia.k8s.io/sharedpool": "160",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.com/cpupool2": "2",
-                                "nokia.com/sharedpool": "10",
+                                "nokia.k8s.io/cpupool2": "2",
+                                "nokia.k8s.io/sharedpool": "160",
                                 "memory": "2000Mi"
                             }
                         }
@@ -109,11 +109,11 @@
                         "imagePullPolicy": "IfNotPresent",
                         "resources": {
                             "requests": {
-                                "nokia.com/cpupool1": "2",
+                                "nokia.k8s.io/cpupool1": "2",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.com/cpupool1": "2",
+                                "nokia.k8s.io/cpupool1": "2",
                                 "memory": "2000Mi"
                             }
                         }

--- a/test/testdata/pod-spec-wrong-excl-pool-value-req.json
+++ b/test/testdata/pod-spec-wrong-excl-pool-value-req.json
@@ -72,15 +72,13 @@
                                 "containerPort": 80
                             }
                         ],
-			"resources": {
+                        "resources": {
                             "requests": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/exclusive-pool": "3",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/exclusive-pool": "3",
                                 "memory": "2000Mi"
                             }
                         }
@@ -92,7 +90,7 @@
                 "namespace": "default",
                 "name": "cpupod",
                 "annotations": {
-                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   }, {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   },{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"3\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool2\"\n   }\n]\n}]\n"
+                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-pool\"\n   },\n   {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\", \"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"pool\": \"exclusive-pool\",\n     \"cpus\": 2\n   } \n]\n}]\n"
                 }
             }
         },

--- a/test/testdata/pod-spec-wrong-pool-value-req.json
+++ b/test/testdata/pod-spec-wrong-pool-value-req.json
@@ -72,15 +72,13 @@
                                 "containerPort": 80
                             }
                         ],
-			"resources": {
+                        "resources": {
                             "requests": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/shared-pool": "120",
                                 "memory": "2000Mi"
                             },
                             "limits": {
-                                "nokia.k8s.io/exclusive-cpupool1": "4",
-                                "nokia.k8s.io/exclusive-cpupool2": "2",
+                                "nokia.k8s.io/shared-pool": "120",
                                 "memory": "2000Mi"
                             }
                         }
@@ -92,7 +90,7 @@
                 "namespace": "default",
                 "name": "cpupod",
                 "annotations": {
-                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   }, {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool1\"\n   },{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"3\"],\n     \"cpus\": 2,\n     \"pool\": \"exclusive-cpupool2\"\n   }\n]\n}]\n"
+                    "nokia.k8s.io/cpus": "[{\n\"container\": \"cputestcontainer\",\n\"processes\":\n  [{\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\",\"/thread_busyloop -n \\\"Process \\\"1\"],\n     \"cpus\": 150,\n     \"pool\": \"shared-pool\"\n   },\n   {\n     \"process\": \"/bin/sh\",\n     \"args\": [\"-c\", \"/thread_busyloop -n \\\"Process \\\"2\"],\n     \"pool\": \"shared-pool\",\n     \"cpus\": 10\n   } \n]\n}]\n"
                 }
             }
         },


### PR DESCRIPTION
All CPU requests from configured pools must be specified in pod spec resources section. The pod annotation is only optional and does not add patches that add resource requests/limits to pod spec.

Validations are added also to make sure pod annotation and pod spec configuration match to each other.