### PR TITLE
Remove CPU affinity setting for shared pools from pinner

### DIFF
--- a/cmd/cpu-device-plugin/cpu-device-plugin.go
+++ b/cmd/cpu-device-plugin/cpu-device-plugin.go
@@ -20,7 +20,6 @@ import (
 	"time"
 )
 
-var poolConfFileName string
 var resourceBaseName = "nokia.k8s.io"
 
 type cpuDeviceManager struct {
@@ -132,7 +131,6 @@ func (cdm *cpuDeviceManager) Allocate(ctx context.Context, rqt *pluginapi.Alloca
 		} else {
 			envmap["EXCLUSIVE_CPUS"] = cpusAllocated[:len(cpusAllocated)-1]
 		}
-		envmap["POOL_CONFIG_FILE"] = poolConfFileName
 		containerResp := new(pluginapi.ContainerAllocateResponse)
 		glog.Infof("CPUs allocated: %s: Num of CPUs %s", cpusAllocated[:len(cpusAllocated)-1],
 			strconv.Itoa(len(container.DevicesIDs)))
@@ -202,7 +200,7 @@ func createPluginsForPools() error {
 		}
 	}
 	var sharedCPUs string
-	poolConf,_,err := types.DeterminePoolConfig()
+	poolConf, _, err := types.DeterminePoolConfig()
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -157,12 +157,6 @@ func patchContainerForPinning(cpuAnnotation types.CPUAnnotation, patchList []pat
 		json.RawMessage(`{"name":"hostbin","mountPath":"/opt/bin","readOnly":true}`)
 	patchList = append(patchList, patchItem)
 
-	//  device plugin config volumeMount.
-	patchItem.Path = "/spec/containers/" + strconv.Itoa(i) + "/volumeMounts/-"
-	patchItem.Value =
-		json.RawMessage(`{"name":"cpu-pooler-config","mountPath":"/etc/cpu-pooler","readOnly":true}`)
-	patchList = append(patchList, patchItem)
-
 	// Container name to env variable
 	contNameEnvPatch := `{"name":"CONTAINER_NAME","value":"` + c.Name + `" }`
 	patchItem.Path = "/spec/containers/" + strconv.Itoa(i) + "/env"
@@ -195,10 +189,6 @@ func patchVolumesForPinning(patchList []patch) []patch {
 	patchItem.Value = json.RawMessage(`{"name":"hostbin","hostPath":{ "path":"/opt/bin"} }`)
 	patchList = append(patchList, patchItem)
 
-	// cpu dp configmap volume
-	patchItem.Path = "/spec/volumes/-"
-	patchItem.Value = json.RawMessage(`{"name":"cpu-pooler-config","configMap":{ "name":"cpu-pooler-configmap"} }`)
-	patchList = append(patchList, patchItem)
 	return patchList
 
 }

--- a/cmd/webhook/webhook_test.go
+++ b/cmd/webhook/webhook_test.go
@@ -164,8 +164,6 @@ func TestMutatePodSharedCpu(t *testing.T) {
 			Value: json.RawMessage(`{"name":"podinfo","mountPath":"/etc/podinfo","readOnly":true}`)},
 		patch{Op: "add", Path: "/spec/containers/0/volumeMounts/-",
 			Value: json.RawMessage(`{"name":"hostbin","mountPath":"/opt/bin","readOnly":true}`)},
-		patch{Op: "add", Path: "/spec/containers/0/volumeMounts/-",
-			Value: json.RawMessage(`{"mountPath":"/etc/cpu-pooler","readOnly":true,"name":"cpu-pooler-config"}`)},
 		patch{Op: "add", Path: "/spec/containers/0/env",
 			Value: json.RawMessage(`[{"name": "CONTAINER_NAME", "value": "cputestcontainer"}]`)},
 		patch{Op: "add", Path: "/spec/containers/0/command",
@@ -174,8 +172,6 @@ func TestMutatePodSharedCpu(t *testing.T) {
 			Value: json.RawMessage(`{"name":"podinfo","downwardAPI": { "items": [ { "path" : "annotations","fieldRef":{ "fieldPath": "metadata.annotations"} } ] } }`)},
 		patch{Op: "add", Path: "/spec/volumes/-",
 			Value: json.RawMessage(`{"name":"hostbin","hostPath":{ "path":"/opt/bin"} }`)},
-		patch{Op: "add", Path: "/spec/volumes/-",
-			Value: json.RawMessage(`{"name":"cpu-pooler-config","configMap":{ "name":"cpu-pooler-configmap"} }`)},
 	}
 	handleAndChekAdmReview(t, admReviewReq, expectedPatches, nil)
 }
@@ -192,8 +188,6 @@ func TestMutatePodExclusiveCpu(t *testing.T) {
 			Value: json.RawMessage(`{"name":"podinfo","mountPath":"/etc/podinfo","readOnly":true}`)},
 		patch{Op: "add", Path: "/spec/containers/0/volumeMounts/-",
 			Value: json.RawMessage(`{"name":"hostbin","mountPath":"/opt/bin","readOnly":true}`)},
-		patch{Op: "add", Path: "/spec/containers/0/volumeMounts/-",
-			Value: json.RawMessage(`{"mountPath":"/etc/cpu-pooler","readOnly":true,"name":"cpu-pooler-config"}`)},
 		patch{Op: "add", Path: "/spec/containers/0/env",
 			Value: json.RawMessage(`[{"name": "CONTAINER_NAME", "value": "cputestcontainer"}]`)},
 		patch{Op: "add", Path: "/spec/containers/0/command",
@@ -202,8 +196,6 @@ func TestMutatePodExclusiveCpu(t *testing.T) {
 			Value: json.RawMessage(`{"name":"podinfo","downwardAPI": { "items": [ { "path" : "annotations","fieldRef":{ "fieldPath": "metadata.annotations"} } ] } }`)},
 		patch{Op: "add", Path: "/spec/volumes/-",
 			Value: json.RawMessage(`{"name":"hostbin","hostPath":{ "path":"/opt/bin"} }`)},
-		patch{Op: "add", Path: "/spec/volumes/-",
-			Value: json.RawMessage(`{"name":"cpu-pooler-config","configMap":{ "name":"cpu-pooler-configmap"} }`)},
 	}
 	handleAndChekAdmReview(t, admReviewReq, expectedPatches, nil)
 }


### PR DESCRIPTION
- CPU affinity setting removed from process starter (pinner). This
  is not needed as cpusetter component will set the cpuset for
  the container.
- Removed pool config reading from process starter and volume mounting
  from wehbhook. Removed also config file env variable setting from DP

Signed-off-by: Timo Lindqvist <timo.lindqvist@nokia.com>