### PR TITLE
Introducing the third CPU pool type called "default"

### DIFF
--- a/deployment/cpu-dp-config.yaml
+++ b/deployment/cpu-dp-config.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   name: cpu-pooler-configmap
 data:
-  cpu-pooler.yaml: |
-    resourceBaseName: "nokia.k8s.io"
   poolconfig-controller.yaml: |
     pools: 
       exclusive-pool:

--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -117,13 +117,13 @@ func (setHandler *SetHandler) adjustContainerSets(pod v1.Pod) {
 func (setHandler *SetHandler) determineCorrectCpuset(pod v1.Pod, container v1.Container) (cpuset.CPUSet, error) {
 	for resourceName := range container.Resources.Requests {
 		resNameAsString := string(resourceName)
-		if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, "shared") {
+		if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, types.SharedPoolID) {
 			return cpuset.Parse(setHandler.poolConfig.SelectPool(resNameAsString).CPUs)
-		} else if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, "exclusive") {
+		} else if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, types.ExclusivePoolID) {
 			return setHandler.getListOfAllocatedExclusiveCpus(resNameAsString, pod, container)
 		}
 	}
-	return cpuset.Parse(setHandler.poolConfig.SelectPool(resourceBaseName + "/default").CPUs)
+	return cpuset.Parse(setHandler.poolConfig.SelectPool(resourceBaseName + "/" + types.DefaultPoolID).CPUs)
 }
 
 func (setHandler *SetHandler) getListOfAllocatedExclusiveCpus(exclusivePoolName string, pod v1.Pod, container v1.Container) (cpuset.CPUSet, error) {

--- a/pkg/types/pool.go
+++ b/pkg/types/pool.go
@@ -10,6 +10,19 @@ import (
 	"path/filepath"
 )
 
+const (
+//SharedPoolID is the constant prefix in the name of the CPU pool. It is used to signal that a CPU pool is of shared type
+	SharedPoolID = "shared"
+//ExclusivePoolID is the constant prefix in the name of the CPU pool. It is used to signal that a CPU pool is of exclusive type
+	ExclusivePoolID = "exclusive"
+//DefaultPoolID is the constant prefix in the name of the CPU pool. It is used to signal that a CPU pool is of default type
+	DefaultPoolID = "default"
+)
+
+var (
+//PoolConfigDir defines the pool configuration file location
+	PoolConfigDir = "/etc/cpu-pooler"
+)
 // Pool defines cpupool
 type Pool struct {
 	CPUs string `yaml:"cpus"`
@@ -21,8 +34,17 @@ type PoolConfig struct {
 	NodeSelector map[string]string `yaml:"nodeSelector"`
 }
 
-// PoolConfigDir defines the pool configuration file location
-var PoolConfigDir = "/etc/cpu-pooler"
+//DeterminePoolType takes the name of CPU pool as defined in the CPU-Pooler ConfigMap, and returns the type of CPU pool it represents.
+//Type of the pool is determined based on the constant prefixes used in the name of the pool.
+//A type can be shared, exclusive, or default.
+func DeterminePoolType(poolName string) string {
+	if strings.HasPrefix(poolName, SharedPoolID) {
+		return SharedPoolID
+	} else if strings.HasPrefix(poolName, ExclusivePoolID) {
+		return ExclusivePoolID  
+	}
+	return DefaultPoolID
+}
 
 //DeterminePoolConfig first interrogates the label set of the Node this process runs on.
 //It uses this information to select the specific PoolConfig file corresponding to the Node.


### PR DESCRIPTION
The idea behind the default pool is that CPUs belonging to this pool need not be advertised as devices.
Workloads not explicitly asking for neither exclusive, nor shared pool resources will be automatically restricted to the "default" pool's CPUset.
For the sake of uniform handling every misconfigured pool (neither exclusive, nor shared) is considered "default" type from now on, and not advertised to Device Manager.