### PR TITLE
Fixing CPUSetter component

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,6 +23,7 @@
 #   non-go = false
 #   go-tests = true
 #   unused-packages = true
+
 [[constraint]]
   name = "github.com/go-yaml/yaml"
   version = "2.2.1"

--- a/cmd/cpu-device-plugin/cpu-device-plugin.go
+++ b/cmd/cpu-device-plugin/cpu-device-plugin.go
@@ -15,7 +15,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -91,14 +90,14 @@ func (cdm *cpuDeviceManager) ListAndWatch(e *pluginapi.Empty, stream pluginapi.D
 		if updateNeeded {
 			resp := new(pluginapi.ListAndWatchResponse)
 			if cdm.poolType == "shared" {
-				nbrOfCPUs := len(strings.Split(cdm.pool.CPUs, ","))
+				nbrOfCPUs := cdm.pool.CPUs.Size()
 				for i := 0; i < nbrOfCPUs*1000; i++ {
 					cpuID := strconv.Itoa(i)
 					resp.Devices = append(resp.Devices, &pluginapi.Device{cpuID, pluginapi.Healthy})
 				}
 			} else {
-				for _, cpuID := range strings.Split(cdm.pool.CPUs, ",") {
-					resp.Devices = append(resp.Devices, &pluginapi.Device{cpuID, pluginapi.Healthy})
+				for _, cpuID := range cdm.pool.CPUs.ToSlice() {
+					resp.Devices = append(resp.Devices, &pluginapi.Device{strconv.Itoa(cpuID), pluginapi.Healthy})
 				}
 			}
 			if err := stream.Send(resp); err != nil {
@@ -204,7 +203,7 @@ func createPluginsForPools() error {
 				glog.Errorf("Pool config : %v", poolConf)
 				break
 			}
-			sharedCPUs = pool.CPUs
+			sharedCPUs = pool.CPUs.String()
 		}
 		cdm := newCPUDeviceManager(poolName, pool, sharedCPUs)
 		if err := cdm.Start(); err != nil {

--- a/cmd/cpusetter/cpusetter.go
+++ b/cmd/cpusetter/cpusetter.go
@@ -33,6 +33,7 @@ func main() {
 	stopChannel := make(chan struct{})
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
+	log.Println("CPUSetter's Controller initalized successfully! Warm-up starts now!")
 	go controller.Run(stopChannel)
 	// Wait until Controller pushes a signal on the stop channel
 	select {


### PR DESCRIPTION
The Controller finally underwent exhaustive testing. This review makes it entirely functioning!
Fixes applied:
- Removed own project from DEP lock file. It should always come from source (not really a fix :))
- Pool names were not correctly selected in the code. Fixed to use the correct type constants
- cpuset cgroups were wrongly accessed. The cpuset.cpus file needs to be opened rather than the directory

After the change, the Controller automatically sets the cpuset.cpus parameters of all the Kubernetes Pod's Container's to the right value; be it related to default, shared, or exclusive pool.