### PR TITLE
Support allocating CPUs from shared pool and from exclusive pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - go test -v ./...
   - docker build -t cpudp -f build/Dockerfile.cpudp .
   - docker build -t cpu-device-webhook -f build/Dockerfile.webhook .
+  - docker build -t cpusetter -f build/Dockerfile.cpusetter  .
   - CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' github.com/nokia/CPU-Pooler/cmd/process-starter

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -195,12 +195,28 @@
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = "UT"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:8548c309c65a85933a625be5e7d52b6ac927ca30c56869fae58123b8a77a75e1"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = "UT"
+  revision = "221dbe5ed46703ee255b1da0dec05086f5035f62"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -628,6 +644,7 @@
     "github.com/golang/glog",
     "github.com/intel/multus-cni/checkpoint",
     "github.com/intel/multus-cni/types",
+    "github.com/stretchr/testify/assert",
     "golang.org/x/net/context",
     "golang.org/x/sys/unix",
     "google.golang.org/grpc",

--- a/deployment/cpu-dev-ds.yaml
+++ b/deployment/cpu-dev-ds.yaml
@@ -1,3 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cpupooler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cpu-pooler
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cpu-pooler
+subjects:
+- kind: ServiceAccount
+  name: cpupooler
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cpu-pooler
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -36,3 +64,4 @@ spec:
       - name: cpu-pooler-config
         configMap:
           name: cpu-pooler-configmap
+      serviceAccountName: cpupooler

--- a/deployment/cpu-dev-ds.yaml
+++ b/deployment/cpu-dev-ds.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cpu-device-plugin
-  namespace: default
+  namespace: kube-system
 spec:
   selector:
     matchLabels:

--- a/deployment/cpu-pooler-config.yaml
+++ b/deployment/cpu-pooler-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cpu-pooler-configmap
+  namespace: kube-system
 data:
   poolconfig-controller.yaml: |
     pools: 

--- a/deployment/cpu-test-exclusive.yaml
+++ b/deployment/cpu-test-exclusive.yaml
@@ -2,22 +2,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: cpupod-exclusive
-  annotations:
-    nokia.k8s.io/cpus: |
-      [{
-      "container": "cputest-exclusive",
-      "processes":
-        [{
-           "process": "/bin/sh",
-           "args": ["-c","/thread_busyloop -n \"Process \"cputest-exclusive"],
-           "cpus": 3,
-           "pool": "exclusive-pool"
-         } 
-      ]
-      }]
 spec:
   containers:
   - name: cputest-exclusive
+    command: [ /thread_busyloop ]
+    args: ["-c","$(EXCLUSIVE_CPUS)"]
     image: busyloop
     imagePullPolicy: IfNotPresent
     ports:
@@ -25,7 +14,7 @@ spec:
     resources:
       requests:
         memory: 2000Mi
-        nokia.k8s.io/exclusive-pool: "3"
+        nokia.k8s.io/exclusive-pool: "2"
       limits:
         memory: 2000Mi
-        nokia.k8s.io/exclusive-pool: "3"
+        nokia.k8s.io/exclusive-pool: "2"

--- a/deployment/cpu-test-shared-exclusive.yaml
+++ b/deployment/cpu-test-shared-exclusive.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cpupod-exclusive
+spec:
+  containers:
+  - name: cputest-exclusive
+    image: busyloop
+    command: [ /thread_busyloop ]
+    args: ["-c","$(EXCLUSIVE_CPUS)","-s","$(SHARED_CPUS)","-n \"Process cputest-exclusive\""]
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 80
+    resources:
+      requests:
+        memory: 2000Mi
+        nokia.k8s.io/exclusive-pool: "2"
+        nokia.k8s.io/shared-pool: "500"
+      limits:
+        memory: 2000Mi
+        nokia.k8s.io/exclusive-pool: "2"
+        nokia.k8s.io/shared-pool: "500"
+

--- a/deployment/cpu-test-shared-exclusive.yaml
+++ b/deployment/cpu-test-shared-exclusive.yaml
@@ -7,7 +7,7 @@ spec:
   - name: cputest-exclusive
     image: busyloop
     command: [ /thread_busyloop ]
-    args: ["-c","$(EXCLUSIVE_CPUS)","-s","$(SHARED_CPUS)","-n \"Process cputest-exclusive\""]
+    args: ["-c","$(EXCLUSIVE_CPUS)","-s","$(SHARED_CPUS)","-n 'Process cputest-exclusive'"]
     imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 80

--- a/deployment/cpu-test.yaml
+++ b/deployment/cpu-test.yaml
@@ -18,13 +18,19 @@ metadata:
            "args": ["-c", "/thread_busyloop -n \"Process \"2"],
            "pool": "exclusive-pool",
            "cpus": 1
+         },
+         {
+           "process": "/bin/sh",
+           "args": ["-c", "/thread_busyloop -n \"Process \"3"],
+           "pool": "shared-pool",
+           "cpus": 100
          } 
       ]
       }]
 spec:
   containers:
   - name: sharedtestcontainer
-    command: [ "/bin/bash", "-c", "--" ]
+    command: [ "/bin/sh", "-c", "--" ]
     args: [ "while true; do sleep 1; done;" ]
     image: busyloop
     imagePullPolicy: IfNotPresent
@@ -39,18 +45,20 @@ spec:
         memory: 2000Mi
   - name: exclusivetestcontainer
     image: busyloop
-    command: [ "/bin/bash", "-c", "--" ]
+    command: [ "/bin/sh", "-c", "--" ]
     args: [ "while true; do sleep 1; done;" ]
     imagePullPolicy: IfNotPresent
     resources:
       requests:
         memory: 2000Mi
         nokia.k8s.io/exclusive-pool: "2"
+        nokia.k8s.io/shared-pool: "100"
       limits:
         memory: 2000Mi
+        nokia.k8s.io/shared-pool: "100"
         nokia.k8s.io/exclusive-pool: "2"
   - name: defaulttestcontainer
-    command: [ "/bin/bash", "-c", "--" ]
+    command: [ "/bin/sh", "-c", "--" ]
     args: [ "while true; do sleep 1; done;" ]
     image: busyloop
     imagePullPolicy: IfNotPresent

--- a/deployment/cpusetter-ds.yaml
+++ b/deployment/cpusetter-ds.yaml
@@ -59,7 +59,7 @@ spec:
         image: cpusetter
         imagePullPolicy: IfNotPresent
         ##--cpusetroot needs to be set to the root of the cgroupfs hierarchy used by Kubelet for workloads
-        command: [ "/cpu-setter", "--poolconfigs=/etc/cpu-pooler", "--cpusetroot=/rootfs/sys/fs/cgroup/cpuset/kubepods" ]
+        command: [ "/cpusetter", "--poolconfigs=/etc/cpu-pooler", "--cpusetroot=/rootfs/sys/fs/cgroup/cpuset/kubepods" ]
         resources:
           requests:
             cpu: "10m"

--- a/deployment/cpusetter-ds.yaml
+++ b/deployment/cpusetter-ds.yaml
@@ -50,6 +50,7 @@ spec:
     matchLabels:
       cpu-pooler: cpu-setter
   template:
+    metadata:
       labels:
         cpu-pooler: cpu-setter
     spec:

--- a/deployment/webhook-conf.yaml
+++ b/deployment/webhook-conf.yaml
@@ -8,7 +8,7 @@ webhooks:
     clientConfig:
       service:
         name: cpu-dev-pod-mutator-svc
-        namespace: default
+        namespace: kube-system
         path: "/mutating-pods"
       caBundle: "${CA_BUNDLE}"
     rules:

--- a/deployment/webhook-svc-depl.yaml
+++ b/deployment/webhook-svc-depl.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cpu-dev-pod-mutator-svc
-  namespace: default
+  namespace: kube-system
   labels:
     app: cpu-dev-pod-mutator 
 spec:
@@ -17,7 +17,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cpu-dev-pod-mutator-deployment
-  namespace: default
+  namespace: kube-system
   labels:
     app: cpu-dev-pod-mutator
 spec:

--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -1,7 +1,6 @@
 package sethandler
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 	"os"
@@ -23,9 +22,8 @@ import (
 )
 
 var (
-	dedicatedPinnerCoreID = 0
-	resourceBaseName      = "nokia.k8s.io"
-	processConfigKey      = resourceBaseName + "/cpus"
+	resourceBaseName = "nokia.k8s.io"
+	processConfigKey = resourceBaseName + "/cpus"
 )
 
 //SetHandler is the data set encapsulating the configuration data needed for the CPUSetter Controller to be able to adjust cpusets
@@ -167,7 +165,6 @@ func (setHandler *SetHandler) getListOfAllocatedExclusiveCpus(exclusivePoolName 
 }
 
 func calculateFinalExclusiveSet(exclusiveCpus *multusTypes.ResourceInfo, pod v1.Pod, container v1.Container) (cpuset.CPUSet, error) {
-	var doesSetContainPinnerCore bool
 	setBuilder := cpuset.NewBuilder()
 	for _, deviceID := range exclusiveCpus.DeviceIDs {
 		deviceIDasInt, err := strconv.Atoi(deviceID)
@@ -175,33 +172,8 @@ func calculateFinalExclusiveSet(exclusiveCpus *multusTypes.ResourceInfo, pod v1.
 			return cpuset.CPUSet{}, err
 		}
 		setBuilder.Add(deviceIDasInt)
-		if deviceIDasInt == dedicatedPinnerCoreID {
-			doesSetContainPinnerCore = true
-		}
-	}
-	if isPinnerUsedByContainer(pod, container.Name) && !doesSetContainPinnerCore {
-		//1: Container is asking exclusive CPUs + 2: Container has a pool configured in the annotation = Pinner will be used
-		//If pinner is used by a container, we need to the add the configured CPU core holding its thread to their cpuset
-		setBuilder.Add(dedicatedPinnerCoreID)
 	}
 	return setBuilder.Result(), nil
-}
-
-func isPinnerUsedByContainer(pod v1.Pod, containerName string) bool {
-	for key, value := range pod.ObjectMeta.Annotations {
-		if strings.Contains(key, processConfigKey) {
-			var processConfig types.CPUAnnotation
-			err := json.Unmarshal([]byte(value), &processConfig)
-			if err != nil {
-				return false
-			}
-			containerConfig := processConfig.ContainerPools(containerName)
-			if len(containerConfig) > 0 {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func determineCid(podStatus v1.PodStatus, containerName string) string {
@@ -215,7 +187,7 @@ func determineCid(podStatus v1.PodStatus, containerName string) string {
 
 func containerIDInPodStatus(podStatus v1.PodStatus, containerID string) bool {
 	for _, containerStatus := range podStatus.ContainerStatuses {
-		if strings.HasSuffix(containerStatus.ContainerID, containerID){
+		if strings.HasSuffix(containerStatus.ContainerID, containerID) {
 			return true
 		}
 	}
@@ -264,7 +236,7 @@ func (setHandler *SetHandler) applyCpusetToContainer(containerID string, cpuset 
 func getInfraContainerPath(podStatus v1.PodStatus, searchPath string) string {
 	var pathToInfraContainer string
 	filelist, _ := filepath.Glob(filepath.Dir(searchPath) + "/*")
-	for _, fpath := range filelist{
+	for _, fpath := range filelist {
 		fstat, err := os.Stat(fpath)
 		if err != nil {
 			continue
@@ -276,7 +248,7 @@ func getInfraContainerPath(podStatus v1.PodStatus, searchPath string) string {
 	return pathToInfraContainer
 }
 
-func (setHandler *SetHandler) applyCpusetToInfraContainer(pod v1.Pod, pathToSearchContainer string ) error{
+func (setHandler *SetHandler) applyCpusetToInfraContainer(pod v1.Pod, pathToSearchContainer string) error {
 	cpuset := setHandler.poolConfig.SelectPool(types.DefaultPoolID).CPUs
 	if cpuset.IsEmpty() {
 		//Nothing to set. We will leave the container running on the Kubernetes provisioned default cpuset
@@ -284,14 +256,14 @@ func (setHandler *SetHandler) applyCpusetToInfraContainer(pod v1.Pod, pathToSear
 		return nil
 	}
 	if pathToSearchContainer == "" {
-		return errors.New("container directory for pod: " +  string(pod.ObjectMeta.UID) + " does not exists under the provided cgroupfs hierarchy:" + setHandler.cpusetRoot)
+		return errors.New("container directory for pod: " + string(pod.ObjectMeta.UID) + " does not exists under the provided cgroupfs hierarchy:" + setHandler.cpusetRoot)
 	}
 	pathToContainerCpusetFile := getInfraContainerPath(pod.Status, pathToSearchContainer)
 	if pathToContainerCpusetFile == "" {
 		return errors.New("cpuset file does not exist for infra container of pod:" + string(pod.ObjectMeta.UID) + " under the provided cgroupfs hierarchy:" + setHandler.cpusetRoot)
 	}
 
-	file, err := os.OpenFile(pathToContainerCpusetFile + "/cpuset.cpus", os.O_WRONLY|os.O_SYNC, 0755)
+	file, err := os.OpenFile(pathToContainerCpusetFile+"/cpuset.cpus", os.O_WRONLY|os.O_SYNC, 0755)
 	if err != nil {
 		return errors.New("Can't open cpuset file:" + pathToContainerCpusetFile + " for infra container:" + filepath.Base(pathToContainerCpusetFile) + " because:" + err.Error())
 	}

--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -3,7 +3,14 @@ package sethandler
 import (
 	"encoding/json"
 	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strconv"
+	"strings"
+	"time"
+
 	"github.com/intel/multus-cni/checkpoint"
 	multusTypes "github.com/intel/multus-cni/types"
 	"github.com/nokia/CPU-Pooler/pkg/types"
@@ -13,12 +20,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
-	"log"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
-	"time"
 )
 
 var (
@@ -125,14 +126,25 @@ func (setHandler *SetHandler) adjustContainerSets(pod v1.Pod) {
 }
 
 func (setHandler *SetHandler) determineCorrectCpuset(pod v1.Pod, container v1.Container) (cpuset.CPUSet, error) {
+	var (
+		sharedCPUSet, exclusiveCPUSet cpuset.CPUSet
+		err                           error
+	)
 	for resourceName := range container.Resources.Requests {
 		resNameAsString := string(resourceName)
 		if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, types.SharedPoolID) {
-			return setHandler.poolConfig.SelectPool(types.SharedPoolID).CPUs, nil
+			sharedCPUSet = setHandler.poolConfig.SelectPool(types.SharedPoolID).CPUs
 		} else if strings.Contains(resNameAsString, resourceBaseName) && strings.Contains(resNameAsString, types.ExclusivePoolID) {
-			return setHandler.getListOfAllocatedExclusiveCpus(resNameAsString, pod, container)
+			exclusiveCPUSet, err = setHandler.getListOfAllocatedExclusiveCpus(resNameAsString, pod, container)
+			if err != nil {
+				return cpuset.CPUSet{}, err
+			}
 		}
 	}
+	if !sharedCPUSet.IsEmpty() || !exclusiveCPUSet.IsEmpty() {
+		return sharedCPUSet.Union(exclusiveCPUSet), nil
+	}
+
 	return setHandler.poolConfig.SelectPool(types.DefaultPoolID).CPUs, nil
 }
 
@@ -158,7 +170,7 @@ func calculateFinalExclusiveSet(exclusiveCpus *multusTypes.ResourceInfo, pod v1.
 	var doesSetContainPinnerCore bool
 	setBuilder := cpuset.NewBuilder()
 	for _, deviceID := range exclusiveCpus.DeviceIDs {
-		deviceIDasInt,err := strconv.Atoi(deviceID)
+		deviceIDasInt, err := strconv.Atoi(deviceID)
 		if err != nil {
 			return cpuset.CPUSet{}, err
 		}
@@ -230,14 +242,14 @@ func (setHandler *SetHandler) applyCpusetToContainer(containerID string, cpuset 
 	}
 	returnContainerPath := pathToContainerCpusetFile
 	//And for our grand finale, we just "echo" the calculated cpuset to the cpuset cgroupfs "file" of the given container
-  //Find child cpuset if it exists (kube-proxy)
+	//Find child cpuset if it exists (kube-proxy)
 	filepath.Walk(pathToContainerCpusetFile, func(path string, f os.FileInfo, err error) error {
 		if f.IsDir() {
 			pathToContainerCpusetFile = path
 		}
 		return nil
 	})
-	file, err := os.OpenFile(pathToContainerCpusetFile + "/cpuset.cpus", os.O_WRONLY|os.O_SYNC, 0755)
+	file, err := os.OpenFile(pathToContainerCpusetFile+"/cpuset.cpus", os.O_WRONLY|os.O_SYNC, 0755)
 	if err != nil {
 		return "", errors.New("Can't open cpuset file:" + pathToContainerCpusetFile + " for container:" + trimmedCid + " because:" + err.Error())
 	}

--- a/pkg/types/cpu-annotation.go
+++ b/pkg/types/cpu-annotation.go
@@ -3,8 +3,9 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"github.com/golang/glog"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 // Process defines process information in pod annotation
@@ -23,7 +24,7 @@ type Container struct {
 }
 
 // CPUAnnotation defines the pod cpu annotation structure
-type CPUAnnotation []Container
+type CPUAnnotation map[string]Container
 
 const (
 	validationErrNoContainerName int = iota
@@ -39,6 +40,11 @@ var validationErrStr = map[int]string{
 	validationErrNoCpus:          "'cpus' field is mandatory in annotation",
 }
 
+func NewCPUAnnotation() CPUAnnotation {
+	c := make(CPUAnnotation)
+	return c
+}
+
 // Containers returns container name string in annotation
 func (cpuAnnotation CPUAnnotation) Containers() []string {
 	var containers []string
@@ -47,6 +53,12 @@ func (cpuAnnotation CPUAnnotation) Containers() []string {
 		containers = append(containers, cont.Name)
 	}
 	return containers
+}
+
+// ContainerExists tells if container exist in annotation
+func (cpuAnnotation CPUAnnotation) ContainerExists(name string) bool {
+	_, exists := cpuAnnotation[name]
+	return exists
 }
 
 // ContainerSharedCPUTime returns sum of cpu time requested from shared pool by a container
@@ -115,13 +127,19 @@ func (cpuAnnotation CPUAnnotation) ContainerTotalCPURequest(pool string, cName s
 }
 
 // Decode unmarshals json annotation to CPUAnnotation
-func (cpuAnnotation *CPUAnnotation) Decode(annotation []byte) error {
-	err := json.Unmarshal(annotation, cpuAnnotation)
+func (cpuAnnotation CPUAnnotation) Decode(annotation []byte) error {
+	// The annotation in pod spec could be a map but for now
+	// it is kept as an array for backwards compatibility
+	containers := make([]Container, 0)
+	err := json.Unmarshal(annotation, &containers)
+	for _, container := range containers {
+		cpuAnnotation[container.Name] = container
+	}
 	if err != nil {
 		glog.Error(err)
 		return err
 	}
-	for _, c := range *cpuAnnotation {
+	for _, c := range cpuAnnotation {
 		if len(c.Name) == 0 {
 			return errors.New(validationErrStr[validationErrNoContainerName])
 		}

--- a/pkg/types/cpu-annotation.go
+++ b/pkg/types/cpu-annotation.go
@@ -40,6 +40,7 @@ var validationErrStr = map[int]string{
 	validationErrNoCpus:          "'cpus' field is mandatory in annotation",
 }
 
+// NewCPUAnnotation returns a new CPUAnnotation
 func NewCPUAnnotation() CPUAnnotation {
 	c := make(CPUAnnotation)
 	return c

--- a/pkg/types/cpu-annotation_test.go
+++ b/pkg/types/cpu-annotation_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var cpuAnnotation CPUAnnotation
@@ -23,9 +24,7 @@ func init() {
 func TestGetContainerPools(t *testing.T) {
 	pools := cpuAnnotation.ContainerPools("Container1")
 
-	if !reflect.DeepEqual(pools, []string{"shared-pool1", "exclusive-pool2"}) {
-		t.Errorf("%v", pools)
-	}
+	assert.ElementsMatch(t, []string{"shared-pool1", "exclusive-pool2"}, pools)
 }
 
 func TestGetContainerCpuRequest(t *testing.T) {
@@ -36,11 +35,9 @@ func TestGetContainerCpuRequest(t *testing.T) {
 }
 
 func TestGetContainers(t *testing.T) {
-
-	if !reflect.DeepEqual([]string{"Container1", "Container2"}, cpuAnnotation.Containers()) {
-		t.Errorf("Get containers failed %v", cpuAnnotation.Containers())
-	}
+	assert.ElementsMatch(t, []string{"Container1", "Container2"}, cpuAnnotation.Containers())
 }
+
 func TestContainerSharedCPUTime(t *testing.T) {
 	if 550 != cpuAnnotation.ContainerSharedCPUTime("Container2") {
 		t.Errorf("CPU request does not match %v", cpuAnnotation.ContainerSharedCPUTime("Container1"))
@@ -52,9 +49,7 @@ func TestContainerDecodeAnnotation(t *testing.T) {
 	ca := CPUAnnotation{}
 	ca.Decode([]byte(podannotation))
 	pools := ca.ContainerPools("cputestcontainer")
-	if !reflect.DeepEqual(pools, []string{"shared-pool1", "exclusive-pool2"}) {
-		t.Errorf("Failed to get pool %v", pools)
-	}
+	assert.ElementsMatch(t, []string{"shared-pool1", "exclusive-pool2"}, pools)
 
 }
 func TestContainerDecodeAnnotationUnmarshalFail(t *testing.T) {

--- a/pkg/types/cpu-annotation_test.go
+++ b/pkg/types/cpu-annotation_test.go
@@ -5,17 +5,20 @@ import (
 	"testing"
 )
 
-var cpuAnnotation = CPUAnnotation{
-	{Name: "Container1", Processes: []Process{
+var cpuAnnotation CPUAnnotation
+
+func init() {
+	cpuAnnotation = NewCPUAnnotation()
+	cpuAnnotation["Container1"] = Container{Name: "Container1", Processes: []Process{
 		{ProcName: "proc1", Args: []string{"-c", "1"}, CPUs: 120, PoolName: "shared-pool1"},
 		{ProcName: "proc2", Args: []string{"-c", "1"}, CPUs: 1, PoolName: "exclusive-pool2"},
-		{ProcName: "proc3", Args: []string{"-c", "1"}, CPUs: 130, PoolName: "shared-pool1"}}},
-	{Name: "Container2", Processes: []Process{
+		{ProcName: "proc3", Args: []string{"-c", "1"}, CPUs: 130, PoolName: "shared-pool1"}}}
+	cpuAnnotation["Container2"] = Container{Name: "Container2", Processes: []Process{
 		{ProcName: "proc4", Args: []string{"-c", "1"}, CPUs: 120, PoolName: "shared-pool1"},
 		{ProcName: "proc5", Args: []string{"-c", "1"}, CPUs: 1, PoolName: "exclusive-pool2"},
 		{ProcName: "proc6", Args: []string{"-c", "1"}, CPUs: 130, PoolName: "shared-pool1"},
-		{ProcName: "proc7", Args: []string{"-c", "1"}, CPUs: 300, PoolName: "shared-pool3"},
-	}}}
+		{ProcName: "proc7", Args: []string{"-c", "1"}, CPUs: 300, PoolName: "shared-pool3"}}}
+}
 
 func TestGetContainerPools(t *testing.T) {
 	pools := cpuAnnotation.ContainerPools("Container1")

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -2,7 +2,7 @@
 
 service="cpu-dev-pod-mutator-svc"
 secret="cpu-dev-webhook-secret"
-namespace="default"
+namespace="kube-system"
 
 # Remove existing csr
 kubectl delete csr ${service}.${namespace} &>/dev/null || true
@@ -37,7 +37,7 @@ if [ ! -s server.crt ]; then
     exit
 fi
 
-kubectl create secret generic ${secret} \
+kubectl create secret generic ${secret} -n ${namespace}\
         --from-file=key.pem=server-key.pem \
         --from-file=cert.pem=server.crt
 


### PR DESCRIPTION
- Container can ask CPUs from one shared pool and from one exclusive
  pool. Allocating CPUs from two pools of same type is not supported

- Fixed example deployment manifests. Examples are using kube-system
  namespace for all CPU pooler components

Closes #17 , #19 

Signed-off-by: Timo Lindqvist <timo.lindqvist@nokia.com>