### PR TITLE
Parameterizing process-starter path and modify cpuset file path check

### DIFF
--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -244,8 +244,9 @@ func (setHandler *SetHandler) applyCpusetToContainer(containerID string, cpuset 
 	trimmedCid := strings.TrimPrefix(containerID, "docker://")
 	var pathToContainerCpusetFile string
 	filepath.Walk(setHandler.cpusetRoot, func(path string, f os.FileInfo, err error) error {
-		if strings.HasSuffix(path, trimmedCid) {
+		if strings.Contains(path, trimmedCid) {
 			pathToContainerCpusetFile = path
+			return filepath.SkipDir
 		}
 		return nil
 	})


### PR DESCRIPTION
- process-starter path can be set by new parameter in webhook
- cpuset file can also be found when container's id is not suffix of the folder's name