### PR TITLE
Reduce logging for exited/completed/not running containers

### DIFF
--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -134,6 +134,12 @@ func shouldPodBeHandled(pod v1.Pod) bool {
 	if setterNodeName == "" || podNodeName == "" || setterNodeName != podNodeName {
 		return false
 	}
+
+	// Pod has exited/completed and all containers have stopped
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/sethandler/controller.go
+++ b/pkg/sethandler/controller.go
@@ -193,9 +193,9 @@ func (setHandler *SetHandler) adjustContainerSets(pod v1.Pod, containersToBeSet 
 		log.Printf("ERROR: Cpuset for the infracontainer of Pod: %s with ID: %s could not be re-adjusted, because: %s", pod.ObjectMeta.Name, pod.ObjectMeta.UID, err)
 		return
 	}
-	err = k8sclient.SetPodAnnotation(pod, resourceBaseName+"~1"+setterAnnotationSuffix, "true")
+	err = k8sclient.SetPodAnnotation(pod, setterAnnotationKey, "true")
 	if err != nil {
-		log.Printf("ERROR: %s ID: %s  annontation cannot update, because: %s", pod.ObjectMeta.Name, pod.ObjectMeta.UID, err)
+		log.Printf("ERROR: %s ID: %s  annotation cannot update, because: %s", pod.ObjectMeta.Name, pod.ObjectMeta.UID, err)
 	}
 }
 


### PR DESCRIPTION
Hello!

Thank you for this project, I've been using it for a little while and it's working very well!

One thing I noted was that (in my deployment) there are quite a few logs generated from trying to set the CPUSet of an exited container. I've created this patch to reduce the logging generated from these exited containers & pods which I have been running and seems stable!

I'll comment inline to clarify why I made the changes

Many thanks for any consideration of this PR 