### PR TITLE
Changing the auto-provisioned CFS limit to account for the full size of the shared pool in mixed allocations case

### DIFF
--- a/cmd/cpusetter/cpusetter.go
+++ b/cmd/cpusetter/cpusetter.go
@@ -21,7 +21,7 @@ func main() {
 	if poolConfigPath == "" || cpusetRoot == "" {
 		log.Fatal("ERROR: Mandatory command-line arguments poolconfigs and cpusetroot were not provided!")
 	}
-	poolConf, _, err := types.DeterminePoolConfig()
+	poolConf, err := types.DeterminePoolConfig()
 	if err != nil {
 		log.Fatal("ERROR: Could not read CPU pool configuration files because: " + err.Error() + ", exiting!")
 	}


### PR DESCRIPTION
Due to how throttling seems to be implemented in the kernel, it is safer to provision the limit for the full summa of a container's cpuset, even if it means shared user threads can temporarily overstep their boundaries.
Otherwise we can face the really undesirable scenario of shared threads throttling the low latency exclusive users running on the same cpuset.
This half-way approach mimics current K8s upstream behaviour (we still have a CFS quota for administrative purposes), but sets it to a level where it effectively never will be a problem in this edge-scenario

TL;DR there seems to be a hard choice between letting shared threads throttle their own exclusives within the same, or other shared threads in other containers; this PR changes the former to the latter when mixed allocations are used