### PR TITLE
(Re-)Implement cpuset re-provisioning for restarted containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 go:
-  - "1.13"
+  - "1.16"
 
 install:
   - go get -u golang.org/x/lint/golint

--- a/build/Dockerfile.cpudp
+++ b/build/Dockerfile.cpudp
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.13-alpine AS build-env
+FROM golang:1.16.6-alpine3.14 AS build-env
 ARG PLUGIN_PATH=github.com/nokia/CPU-Pooler
 
 RUN apk add curl git

--- a/build/Dockerfile.cpusetter
+++ b/build/Dockerfile.cpusetter
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.13-alpine AS build-env
+FROM golang:1.16.6-alpine3.14 AS build-env
 ARG PLUGIN_PATH=github.com/nokia/CPU-Pooler
 
 RUN apk add curl git

--- a/build/Dockerfile.ut
+++ b/build/Dockerfile.ut
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine3.10 AS builder
+FROM golang:1.16.6-alpine3.14 AS builder
 MAINTAINER Levente Kale <levente.kale@nokia.com>
 
 RUN apk add --no-cache ca-certificates make git bash sudo

--- a/build/Dockerfile.webhook
+++ b/build/Dockerfile.webhook
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.13-alpine AS build-env
+FROM golang:1.16.6-alpine3.14 AS build-env
 ARG PLUGIN_PATH=github.com/nokia/CPU-Pooler
 
 RUN apk add curl git

--- a/go.sum
+++ b/go.sum
@@ -699,6 +699,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -65,6 +65,17 @@ func RefreshPod(pod v1.Pod) (*v1.Pod, error) {
 	return cSet.CoreV1().Pods(pod.ObjectMeta.Namespace).Get(context.TODO(), pod.ObjectMeta.Name, metav1.GetOptions{})
 }
 
+//GetMyPods returns all the Pods to the caller running on the same node as this process
+//Node is identified by the NODE_NAME environment variable. The Pods are filtered based on their spec.nodeName attribute
+func GetMyPods() (*v1.PodList, error) {
+	cSet, err := createClientSet()
+	if err != nil {
+		return nil, err
+	}
+	nodeName := os.Getenv("NODE_NAME")
+	return cSet.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName})
+}
+
 func createClientSet() (*kubernetes.Clientset, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-go mod download
-go install -mod=vendor -a -ldflags "-extldflags '-static'" github.com/nokia/CPU-Pooler/cmd/fakelscpu
+go mod vendor
+go install -a -ldflags "-extldflags '-static'" github.com/nokia/CPU-Pooler/cmd/fakelscpu
 rm -rf /usr/bin/lscpu
 cp ${GOPATH}/bin/fakelscpu /usr/bin/lscpu
 go test -v github.com/nokia/CPU-Pooler/test/...


### PR DESCRIPTION
As the result of the recent processing performance-increasing re-architecting restarted containers do not get their cpusets re-provisioned. This is because we stopped listening to UPDATE Events arriving from the Pod API

This PR re-introduces this functionality in the form of an independent reconciliation loop. We now pro-actively start a periodic reconciliation loop to check if all containers of all Pods on our Node are equipped with their intended cpusets

If not, it means said container was restarted, and we need to reset their cpuset to the intended value. As we can easily do that based on the Pods previously provisioned environment variables, we can have the intended functionality without needing to weather the constant assault of UPDATE events coming from the API server